### PR TITLE
解决为pager添加监听后，长按无法停止scroll的问题

### DIFF
--- a/src/cn/trinea/android/view/autoscrollviewpager/AutoScrollViewPager.java
+++ b/src/cn/trinea/android/view/autoscrollviewpager/AutoScrollViewPager.java
@@ -168,10 +168,12 @@ public class AutoScrollViewPager extends ViewPager {
      * <li>if event is up, start auto scroll again.</li>
      * </ul>
      */
-    @Override
-    public boolean onTouchEvent(MotionEvent ev) {
+   @Override
+    public boolean dispatchTouchEvent(MotionEvent ev) {
+        int action = MotionEventCompat.getActionMasked(ev);
+
         if (stopScrollWhenTouch) {
-            if (ev.getAction() == MotionEvent.ACTION_DOWN && isAutoScroll) {
+            if ((action == MotionEvent.ACTION_DOWN ) && isAutoScroll) {
                 isStopByTouch = true;
                 stopAutoScroll();
             } else if (ev.getAction() == MotionEvent.ACTION_UP && isStopByTouch) {
@@ -202,11 +204,12 @@ public class AutoScrollViewPager extends ViewPager {
                     }
                     getParent().requestDisallowInterceptTouchEvent(true);
                 }
-                return super.onTouchEvent(ev);
+                return super.dispatchTouchEvent(ev);
             }
         }
         getParent().requestDisallowInterceptTouchEvent(true);
-        return super.onTouchEvent(ev);
+
+        return super.dispatchTouchEvent(ev);
     }
 
     private class MyHandler extends Handler {


### PR DESCRIPTION
只是将代码从onTouchEvent移到了dispatchTouchEvent当中，这样就可以先处理逻辑，而不是由子View去决定是否消费掉该事件，消费掉就无法执行到ViewPager的onTouchEvent了。
