### PR TITLE
add info about using 'autoscrollviewpager' lib with `support-v13` lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,16 @@ Maven:
 ```  
 
 Gradle:  
-``` xml
+```.Groovy
 compile 'cn.trinea.android.view.autoscrollviewpager:android-auto-scroll-view-pager:1.1.2'
 ```  
+
+For `support-v13` users (for those, who is using view pager with **native** fragments):
+```.Groovy
+    compile ('cn.trinea.android.view.autoscrollviewpager:android-auto-scroll-view-pager:1.1.2') {
+        exclude group: 'com.google.android', module: 'support-v4'
+    }
+```
 
 ## Contact Me
 - [trinea@google plus](https://plus.google.com/u/0/111989205221366883984)


### PR DESCRIPTION
I am using "native" fragments instead of `android.support.v4.app.Fragment` and target `4.1` only. That's why I only have 

``` .Groovy
    compile 'com.android.support:appcompat-v7:21.0.+'
    compile 'com.android.support:support-v13:21.0.+' 
    compile 'com.viewpagerindicator:library:2.4.1@aar'
```

When I just add

``` .Groovy
   compile 'cn.trinea.android.view.autoscrollviewpager:android-auto-scroll-view-pager:1.1.2'
```

I have compilation errors like this:

```
.../.../Fragment.java:233: error: cannot find symbol
            final View switchContainer = MenuItemCompat.getActionView(filtersMenuItem);
                                                       ^
  symbol:   method getActionView(MenuItem)
  location: class MenuItemCompat

.../.../Fragment.java:291: error: cannot find symbol
            MenuItemCompat.setOnActionExpandListener(searchItem, new MenuItemCompat.OnActionExpandListener() {
                                                                                   ^
  symbol:   class OnActionExpandListener
  location: class MenuItemCompat
```

I assume, that it's because of conflicts of `support-v13` and `support-v4` libs.

Anyway, when I remove `support-v4` lib from dependency of `android-auto-scroll-view-pager` lib, then all errors disappear. I guess, it's worth to add this information to 1st readme page. It could safe some hours for another people, who have same configuration.
